### PR TITLE
feat: Add flatpak and snap support

### DIFF
--- a/src/localsend_extension.py
+++ b/src/localsend_extension.py
@@ -75,7 +75,7 @@ class LocalSendExtension(Nautilus.MenuProvider, GObject.GObject):
                 subprocess.Popen(command)
                 return
             # Try Flatpak
-            flatpak_cmd = ["flatpak", "run", "app.localsend.localsend"] + filepaths
+            flatpak_cmd = ["flatpak", "run", "org.localsend.localsend_app"] + filepaths
             try:
                 subprocess.Popen(flatpak_cmd)
                 return

--- a/src/localsend_extension.py
+++ b/src/localsend_extension.py
@@ -61,7 +61,6 @@ class LocalSendExtension(Nautilus.MenuProvider, GObject.GObject):
                 "localsend",      # Alternative name
                 "LocalSend",      # Capitalized version
             ]
-            
             # Find which LocalSend command is available
             localsend_cmd = None
             for cmd in localsend_commands:
@@ -71,16 +70,23 @@ class LocalSendExtension(Nautilus.MenuProvider, GObject.GObject):
                     break
                 except subprocess.CalledProcessError:
                     continue
-            
-            if localsend_cmd is None:
-                print("LocalSend not found. Please install LocalSend or check if it's in your PATH.")
+            if localsend_cmd is not None:
+                command = [localsend_cmd] + filepaths
+                subprocess.Popen(command)
                 return
-            
-            # Build command with all file paths
-            command = [localsend_cmd] + filepaths
-            
-            # Launch LocalSend with the files
-            subprocess.Popen(command)
-            
+            # Try Flatpak
+            flatpak_cmd = ["flatpak", "run", "app.localsend.localsend"] + filepaths
+            try:
+                subprocess.Popen(flatpak_cmd)
+                return
+            except Exception:
+                pass
+            # Try Snap
+            snap_cmd = ["snap", "run", "localsend"] + filepaths
+            try:
+                subprocess.Popen(snap_cmd)
+                return
+            except Exception:
+                pass
         except Exception as e:
             print(f"Failed to send files with LocalSend: {e}")


### PR DESCRIPTION
This pull request updates the logic for invoking the LocalSend application to send files, improving compatibility with different installation methods. The main change is to attempt launching LocalSend via Flatpak or Snap if the standard command is not found.

Improvements to LocalSend invocation:

* Updated `_send_with_localsend` in `src/localsend_extension.py` to try launching LocalSend with Flatpak (`org.localsend.localsend_app`) and Snap (`localsend`) if the standard command is unavailable, increasing robustness across different installation types.
* Removed the early exit and error message when LocalSend is not found, replacing it with fallback attempts for Flatpak and Snap.

Code cleanup:

* Removed an unnecessary blank line in the list of LocalSend command variants.